### PR TITLE
fixed to works on 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "bindings": "*",
     "debug": "*",
-    "readable-stream": "0"
+    "readable-stream": "1.0.x"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Added latest `readable-streams` dependancy
