### PR TITLE
Fixed afterPacketout() to retry recoverable warnings

### DIFF
--- a/lib/decoder-stream.js
+++ b/lib/decoder-stream.js
@@ -133,7 +133,11 @@ DecoderStream.prototype.pagein = function (page, packets, fn) {
       packet._callback = afterPacketRead;
       self.packets.push(packet);
       self.emit('_packet');
-    } else {
+    } else if (-1 === rtn) {
+      // libogg issued a sync warning, usually recoverable, try it again. 
+      // http://xiph.org/ogg/doc/libogg/ogg_stream_packetout.html
+	   packetout();
+    } else { // libogg returned an unrecoverable error
       fn(new Error('ogg_stream_packetout() error: ' + rtn));
     }
   }


### PR DESCRIPTION
Added extra handling in DecoderStream.afterPacketout() to deal with recoverable errors in libogg's ogg_stream_packetout.

Now afterPacketout() will correctly retry when ogg_stream_packetout sets rtn = -1

This makes node-ogg more resilient to imperfect (but perfectly usable) ogg streams.

For more info: http://xiph.org/ogg/doc/libogg/ogg_stream_packetout.html
